### PR TITLE
Added .clang-format style config file.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+BasedOnStyle: Google
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBraces: Allman
+AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: false
+# 80 is too little
+ColumnLimit: 100


### PR DESCRIPTION
To be able to format the code by using clang-format, styling rules
are needed. The rules do not break the code when clang-format
version 3.7.0 is used.

The rules were picked from the WFS plugin code of SmartMet Server.
I hope the rules also are proper for this project.