### PR TITLE
Bugfix for area- and sounding_type-options (BRAINSTORM-1605).

### DIFF
--- a/observation/DummyCache.cpp
+++ b/observation/DummyCache.cpp
@@ -6,7 +6,12 @@ namespace Engine
 {
 namespace Observation
 {
-void DummyCache::initializeConnectionPool(int finCacheDuration) {}
+DummyCache::DummyCache(const EngineParametersPtr &p) : itsParameters(p) {}
+
+void DummyCache::initializeConnectionPool(int)
+{
+  logMessage("[Observation Engine] Dummy cache initialized!", itsParameters->quiet);
+}
 
 Spine::TimeSeries::TimeSeriesVectorPtr DummyCache::valuesFromCache(Settings &settings)
 {

--- a/observation/DummyCache.h
+++ b/observation/DummyCache.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "EngineParameters.h"
 #include "ObservationCache.h"
 #include "Settings.h"
 
@@ -18,6 +19,8 @@ class ObservableProperty;
 class DummyCache : public ObservationCache
 {
  public:
+  DummyCache(const EngineParametersPtr &p);
+
   void initializeConnectionPool(int finCacheDuration);
 
   Spine::TimeSeries::TimeSeriesVectorPtr valuesFromCache(Settings &settings);
@@ -85,6 +88,9 @@ class DummyCache : public ObservationCache
       std::vector<std::string> &parameters, const std::string language) const;
   bool cacheHasStations() const;
   void shutdown();
+
+ private:
+  EngineParametersPtr itsParameters;
 };
 
 }  // namespace Observation

--- a/observation/ObservationCacheFactory.cpp
+++ b/observation/ObservationCacheFactory.cpp
@@ -17,7 +17,7 @@ ObservationCache* ObservationCacheFactory::create(const EngineParametersPtr& p,
   else if (p->cacheDB == "postgresql")
     return (new PostgreSQLCache(p, cfg));
   else if (p->cacheDB == "dummy")
-    return (new DummyCache());
+    return (new DummyCache(p));
 
   return nullptr;
 }

--- a/observation/PostgreSQL.cpp
+++ b/observation/PostgreSQL.cpp
@@ -1643,12 +1643,8 @@ SmartMet::Spine::TimeSeries::TimeSeriesVectorPtr PostgreSQL::getCachedMobileAndE
 
     ExternalAndMobileDBInfo dbInfo(&producerMeasurand);
 
-    std::string sqlStmt =
-        dbInfo.sqlSelectFromCache(measurandIds,
-                                  settings.starttime,
-                                  settings.endtime,
-                                  "",
-                                  std::map<std::string, std::vector<std::string>>());
+    std::string sqlStmt = dbInfo.sqlSelectFromCache(
+        measurandIds, settings.starttime, settings.endtime, settings.wktArea, settings.dataFilter);
 
     pqxx::result result_set = itsDB.executeNonTransaction(sqlStmt);
 
@@ -1689,7 +1685,7 @@ SmartMet::Spine::TimeSeries::TimeSeriesVectorPtr PostgreSQL::getCachedMobileAndE
   }
   catch (...)
   {
-    throw Spine::Exception::Trace(BCP, "Getting RoadCloud data from database failed!");
+    throw Spine::Exception::Trace(BCP, "Getting mobile data from database failed!");
   }
 }
 

--- a/observation/Settings.h
+++ b/observation/Settings.h
@@ -58,9 +58,10 @@ class Settings
 
   std::set<std::string> stationgroup_codes;
   std::set<uint> producer_ids;
-  // Filters mobile and external data based on geven parameters, e.g.
-  // "stations_no" -> "1020,1046" returns data rows only where station_no == 1020 or 1046
-  std::map<std::string, std::vector<std::string>> mobileAndExternalDataFilter;
+  // Filters mobile and external data and sounding data. Filtering is
+  // based on given parameters, for example "stations_no" -> "1020,1046"
+  // returns data rows only where station_no == 1020 or 1046
+  std::map<std::string, std::vector<std::string>> dataFilter;
   bool useDataCache;  // default is true
 };
 

--- a/observation/SpatiaLite.cpp
+++ b/observation/SpatiaLite.cpp
@@ -1102,13 +1102,12 @@ SmartMet::Spine::TimeSeries::TimeSeriesVectorPtr SpatiaLite::getCachedMobileAndE
 
     ExternalAndMobileDBInfo dbInfo(&producerMeasurand);
 
-    std::string sqlStmt =
-        dbInfo.sqlSelectFromCache(measurandIds,
-                                  settings.starttime,
-                                  settings.endtime,
-                                  "",
-                                  std::map<std::string, std::vector<std::string>>(),
-                                  true);
+    std::string sqlStmt = dbInfo.sqlSelectFromCache(measurandIds,
+                                                    settings.starttime,
+                                                    settings.endtime,
+                                                    settings.wktArea,
+                                                    settings.dataFilter,
+                                                    true);
 
     sqlite3pp::query qry(itsDB, sqlStmt.c_str());
 

--- a/smartmet-engine-observation.spec
+++ b/smartmet-engine-observation.spec
@@ -3,7 +3,7 @@
 %define SPECNAME smartmet-engine-%{DIRNAME}
 Summary: SmartMet Observation Engine
 Name: %{SPECNAME}
-Version: 19.5.21
+Version: 19.5.23
 Release: 1%{?dist}.fmi
 License: FMI
 Group: SmartMet/Engines
@@ -97,6 +97,11 @@ rm -rf $RPM_BUILD_ROOT
 %{_includedir}/smartmet/engines/%{DIRNAME}
 
 %changelog
+* Thu May 23 2019 Anssi Reponen <anssi.reponen@fmi.fi> - 19.5.23-1.fmi
+- Bugfix for mobile observations: area- and sounding_type-parameter taken into consideration when fetched data from cache
+- Added log message of Dummy cache is creation
+- Name of mobileAndExternalDataFilter changed to dataFilter in observation engine settings since it is used also in sounding-query
+
 * Tue May 21 2019 Mika Heiskanen <mika.heiskanen@fmi.fi> - 19.5.21-1.fmi
 - Fixed SmartSymbol to be a known meta parameter
 


### PR DESCRIPTION
- Bugfix for mobile observations: area- and sounding_type-parameter taken into consideration when fetched data from cache
- Added log message of Dummy cache is creation
- Name of mobileAndExternalDataFilter changed to dataFilter in observation engine settings since it is used also in sounding-query