### PR TITLE
Major code refactoring. Big changes in Engine-interface (BRAINSTORM-1…

### DIFF
--- a/observation/DataItem.cpp
+++ b/observation/DataItem.cpp
@@ -15,6 +15,7 @@ std::size_t DataItem::hash_value() const
   {
     std::size_t hash = boost::hash_value(fmisid);
     boost::hash_combine(hash, boost::hash_value(measurand_id));
+    boost::hash_combine(hash, boost::hash_value(sensor_no));
     boost::hash_combine(hash, boost::hash_value(producer_id));
     boost::hash_combine(hash, boost::hash_value(measurand_no));
     boost::hash_combine(hash, boost::hash_value(Fmi::to_iso_string(data_time)));
@@ -36,8 +37,8 @@ std::size_t DataItem::hash_value() const
 std::ostream& operator<<(std::ostream& out, const SmartMet::Engine::Observation::DataItem& item)
 {
   out << Fmi::to_iso_string(item.data_time) << ' ' << Fmi::to_iso_string(item.modified_last) << ' '
-      << Fmi::to_string(item.fmisid) << ' ' << Fmi::to_string(item.measurand_id) << ' '
-      << Fmi::to_string(item.measurand_no) << ' ' << Fmi::to_string(item.data_value) << ' '
-      << Fmi::to_string(item.hash_value());
+      << Fmi::to_string(item.fmisid) << ' ' << Fmi::to_string(item.sensor_no) << ' '
+      << Fmi::to_string(item.measurand_id) << ' ' << Fmi::to_string(item.measurand_no) << ' '
+      << Fmi::to_string(item.data_value) << ' ' << Fmi::to_string(item.hash_value());
   return out;
 };

--- a/observation/DataItem.h
+++ b/observation/DataItem.h
@@ -18,6 +18,7 @@ class DataItem
   boost::posix_time::ptime modified_last;
   double data_value = 0;
   int fmisid = 0;
+  int sensor_no = 0;
   int measurand_id = 0;
   int producer_id = 0;
   int measurand_no = 0;

--- a/observation/DatabaseDriverInterface.h
+++ b/observation/DatabaseDriverInterface.h
@@ -4,6 +4,7 @@
 #include "QueryBase.h"
 #include "QueryResultBase.h"
 #include "Settings.h"
+#include "StationSettings.h"
 #include "Utils.h"
 #include <boost/atomic.hpp>
 #include <boost/thread/condition.hpp>
@@ -29,18 +30,29 @@ class DatabaseDriverInterface
   virtual Spine::TimeSeries::TimeSeriesVectorPtr values(Settings &settings) = 0;
   virtual Spine::TimeSeries::TimeSeriesVectorPtr values(
       Settings &settings, const Spine::TimeSeriesGeneratorOptions &timeSeriesOptions) = 0;
-  virtual boost::shared_ptr<Spine::Table> makeQuery(
-      Settings &settings, boost::shared_ptr<Spine::ValueFormatter> &valueFormatter) = 0;
+  virtual Spine::TaggedFMISIDList translateToFMISID(
+      const boost::posix_time::ptime &starttime,
+      const boost::posix_time::ptime &endtime,
+      const std::string &stationtype,
+      const StationSettings &stationSettings) const = 0;
   virtual void makeQuery(QueryBase *qb) = 0;
   virtual FlashCounts getFlashCount(const boost::posix_time::ptime &starttime,
                                     const boost::posix_time::ptime &endtime,
-                                    const Spine::TaggedLocationList &locations) = 0;
-  virtual boost::shared_ptr<std::vector<ObservableProperty> > observablePropertyQuery(
+                                    const Spine::TaggedLocationList &locations) const = 0;
+  virtual boost::shared_ptr<std::vector<ObservableProperty>> observablePropertyQuery(
       std::vector<std::string> &parameters, const std::string language) = 0;
 
-  virtual void getStations(Spine::Stations &stations, Settings &settings) = 0;
+  virtual void getStations(Spine::Stations &stations, const Settings &settings) const = 0;
+  virtual void getStationsByArea(Spine::Stations &stations,
+                                 const std::string &stationtype,
+                                 const boost::posix_time::ptime &starttime,
+                                 const boost::posix_time::ptime &endtime,
+                                 const std::string &areaWkt) const = 0;
+  virtual void getStationsByBoundingBox(Spine::Stations &stations,
+                                        const Settings &settings) const = 0;
+
   virtual void shutdown() = 0;
-  virtual MetaData metaData(const std::string &producer) = 0;
+  virtual MetaData metaData(const std::string &producer) const = 0;
   virtual std::string id() const = 0;
 
  protected:

--- a/observation/DummyCache.cpp
+++ b/observation/DummyCache.cpp
@@ -32,18 +32,6 @@ Spine::TimeSeries::TimeSeriesVectorPtr DummyCache::valuesFromCache(
   return Spine::TimeSeries::TimeSeriesVectorPtr();
 }
 
-Spine::Stations DummyCache::getStationsByTaggedLocations(
-    const Spine::TaggedLocationList &taggedLocations,
-    const int numberofstations,
-    const std::string &stationtype,
-    const int maxdistance,
-    const std::set<std::string> &stationgroup_codes,
-    const boost::posix_time::ptime &starttime,
-    const boost::posix_time::ptime &endtime)
-{
-  return Spine::Stations();
-}
-
 bool DummyCache::dataAvailableInCache(const Settings &settings) const
 {
   return false;
@@ -53,37 +41,6 @@ bool DummyCache::flashIntervalIsCached(const boost::posix_time::ptime &starttime
                                        const boost::posix_time::ptime &endtime) const
 {
   return false;
-}
-
-void DummyCache::getStationsByBoundingBox(Spine::Stations &stations, const Settings &settings) const
-{
-}
-
-void DummyCache::updateStationsAndGroups(const StationInfo &info) const {}
-
-Spine::Stations DummyCache::findAllStationsFromGroups(
-    const std::set<std::string> stationgroup_codes,
-    const StationInfo &info,
-    const boost::posix_time::ptime &starttime,
-    const boost::posix_time::ptime &endtime) const
-{
-  return Spine::Stations();
-}
-
-bool DummyCache::getStationById(Spine::Station &station,
-                                int station_id,
-                                const std::set<std::string> &stationgroup_codes,
-                                const boost::posix_time::ptime &starttime,
-                                const boost::posix_time::ptime &endtime) const
-{
-  return false;
-}
-
-Spine::Stations DummyCache::findStationsInsideArea(const Settings &settings,
-                                                   const std::string &areaWkt,
-                                                   const StationInfo &info) const
-{
-  return Spine::Stations();
 }
 
 FlashCounts DummyCache::getFlashCount(const boost::posix_time::ptime &starttime,
@@ -191,17 +148,10 @@ std::size_t DummyCache::fillNetAtmoCache(
 
 void DummyCache::cleanNetAtmoCache(const boost::posix_time::time_duration &timetokeep) const {}
 
-void DummyCache::fillLocationCache(const LocationItems &locations) const {}
-
 boost::shared_ptr<std::vector<ObservableProperty> > DummyCache::observablePropertyQuery(
     std::vector<std::string> &parameters, const std::string language) const
 {
   return boost::shared_ptr<std::vector<ObservableProperty> >();
-}
-
-bool DummyCache::cacheHasStations() const
-{
-  return false;
 }
 
 void DummyCache::shutdown() {}

--- a/observation/DummyCache.h
+++ b/observation/DummyCache.h
@@ -31,32 +31,10 @@ class DummyCache : public ObservationCache
   Spine::TimeSeries::TimeSeriesVectorPtr valuesFromCache(Settings &settings);
   Spine::TimeSeries::TimeSeriesVectorPtr valuesFromCache(
       Settings &settings, const Spine::TimeSeriesGeneratorOptions &timeSeriesOptions);
-  Spine::Stations getStationsByTaggedLocations(const Spine::TaggedLocationList &taggedLocations,
-                                               const int numberofstations,
-                                               const std::string &stationtype,
-                                               const int maxdistance,
-                                               const std::set<std::string> &stationgroup_codes,
-                                               const boost::posix_time::ptime &starttime,
-                                               const boost::posix_time::ptime &endtime);
 
   bool dataAvailableInCache(const Settings &settings) const;
   bool flashIntervalIsCached(const boost::posix_time::ptime &starttime,
                              const boost::posix_time::ptime &endtime) const;
-  void getStationsByBoundingBox(Spine::Stations &stations, const Settings &settings) const;
-  void updateStationsAndGroups(const StationInfo &info) const;
-
-  Spine::Stations findAllStationsFromGroups(const std::set<std::string> stationgroup_codes,
-                                            const StationInfo &info,
-                                            const boost::posix_time::ptime &starttime,
-                                            const boost::posix_time::ptime &endtime) const;
-  bool getStationById(Spine::Station &station,
-                      int station_id,
-                      const std::set<std::string> &stationgroup_codes,
-                      const boost::posix_time::ptime &starttime,
-                      const boost::posix_time::ptime &endtime) const;
-  Spine::Stations findStationsInsideArea(const Settings &settings,
-                                         const std::string &areaWkt,
-                                         const StationInfo &info) const;
   FlashCounts getFlashCount(const boost::posix_time::ptime &starttime,
                             const boost::posix_time::ptime &endtime,
                             const Spine::TaggedLocationList &locations) const;
@@ -90,11 +68,8 @@ class DummyCache : public ObservationCache
   std::size_t fillNetAtmoCache(const MobileExternalDataItems &mobileExternalCacheData) const;
   void cleanNetAtmoCache(const boost::posix_time::time_duration &timetokeep) const;
 
-  void fillLocationCache(const LocationItems &locations) const;
-
   boost::shared_ptr<std::vector<ObservableProperty> > observablePropertyQuery(
       std::vector<std::string> &parameters, const std::string language) const;
-  bool cacheHasStations() const;
   void shutdown();
 
  private:

--- a/observation/DummyDatabaseDriver.cpp
+++ b/observation/DummyDatabaseDriver.cpp
@@ -27,15 +27,18 @@ ts::TimeSeriesVectorPtr DummyDatabaseDriver::values(Settings &settings,
   return boost::make_shared<ts::TimeSeriesVector>();
 }
 
-boost::shared_ptr<Spine::Table> DummyDatabaseDriver::makeQuery(
-    Settings &settings, boost::shared_ptr<Spine::ValueFormatter> &)
+Spine::TaggedFMISIDList DummyDatabaseDriver::translateToFMISID(
+    const boost::posix_time::ptime &starttime,
+    const boost::posix_time::ptime &endtime,
+    const std::string &stationtype,
+    const StationSettings &stationSettings) const
 {
-  return boost::make_shared<Spine::Table>();
+  return Spine::TaggedFMISIDList();
 }
 
 FlashCounts DummyDatabaseDriver::getFlashCount(const boost::posix_time::ptime &,
                                                const boost::posix_time::ptime &,
-                                               const Spine::TaggedLocationList &)
+                                               const Spine::TaggedLocationList &) const
 {
   return FlashCounts();
 }

--- a/observation/DummyDatabaseDriver.h
+++ b/observation/DummyDatabaseDriver.h
@@ -21,18 +21,28 @@ class DummyDatabaseDriver : public DatabaseDriverInterface
   Spine::TimeSeries::TimeSeriesVectorPtr values(Settings &settings);
   Spine::TimeSeries::TimeSeriesVectorPtr values(
       Settings &settings, const Spine::TimeSeriesGeneratorOptions &timeSeriesOptions);
-  boost::shared_ptr<Spine::Table> makeQuery(
-      Settings &settings, boost::shared_ptr<Spine::ValueFormatter> &valueFormatter);
+  Spine::TaggedFMISIDList translateToFMISID(const boost::posix_time::ptime &starttime,
+                                            const boost::posix_time::ptime &endtime,
+                                            const std::string &stationtype,
+                                            const StationSettings &stationSettings) const;
   void makeQuery(QueryBase *) {}
   FlashCounts getFlashCount(const boost::posix_time::ptime &starttime,
                             const boost::posix_time::ptime &endtime,
-                            const Spine::TaggedLocationList &locations);
-  boost::shared_ptr<std::vector<ObservableProperty> > observablePropertyQuery(
+                            const Spine::TaggedLocationList &locations) const;
+  boost::shared_ptr<std::vector<ObservableProperty>> observablePropertyQuery(
       std::vector<std::string> &parameters, const std::string language);
-  void getStations(Spine::Stations &, Settings &) {}
+  void getStations(Spine::Stations &stations, const Settings &settings) const {}
+  virtual void getStationsByArea(Spine::Stations &stations,
+                                 const std::string &stationtype,
+                                 const boost::posix_time::ptime &starttime,
+                                 const boost::posix_time::ptime &endtime,
+                                 const std::string &wkt) const
+  {
+  }
+  void getStationsByBoundingBox(Spine::Stations &stations, const Settings &settings) const {}
 
   void shutdown() {}
-  MetaData metaData(const std::string &) { return MetaData(); }
+  MetaData metaData(const std::string &) const { return MetaData(); }
   std::string id() const { return "dummy"; }
 
  private:

--- a/observation/Engine.h
+++ b/observation/Engine.h
@@ -23,15 +23,12 @@ class Engine : public SmartMet::Spine::SmartMetEngine
   Spine::TimeSeries::TimeSeriesVectorPtr values(
       Settings &settings, const Spine::TimeSeriesGeneratorOptions &timeSeriesOptions);
 
-  boost::shared_ptr<Spine::Table> makeQuery(
-      Settings &settings, boost::shared_ptr<Spine::ValueFormatter> &valueFormatter);
-
   void makeQuery(QueryBase *qb);
 
   FlashCounts getFlashCount(const boost::posix_time::ptime &starttime,
                             const boost::posix_time::ptime &endtime,
                             const Spine::TaggedLocationList &locations);
-  boost::shared_ptr<std::vector<ObservableProperty> > observablePropertyQuery(
+  boost::shared_ptr<std::vector<ObservableProperty>> observablePropertyQuery(
       std::vector<std::string> &parameters, const std::string language);
 
   bool ready() const;
@@ -41,14 +38,13 @@ class Engine : public SmartMet::Spine::SmartMetEngine
   const std::shared_ptr<DBRegistry> dbRegistry() const { return itsDatabaseRegistry; }
   void getStations(Spine::Stations &stations, Settings &settings);
 
-  Spine::Stations getStationsByArea(const Settings &settings, const std::string &areaWkt);
+  void getStationsByArea(Spine::Stations &stations,
+                         const std::string &stationtype,
+                         const boost::posix_time::ptime &starttime,
+                         const boost::posix_time::ptime &endtime,
+                         const std::string &areaWkt);
 
   void getStationsByBoundingBox(Spine::Stations &stations, const Settings &settings);
-
-  void getStationsByRadius(Spine::Stations &stations,
-                           const Settings &settings,
-                           double longitude,
-                           double latitude);
 
   /* \brief Test if the given alias name is configured and it has a field for
    * the stationType.
@@ -87,6 +83,12 @@ class Engine : public SmartMet::Spine::SmartMetEngine
   std::set<std::string> getValidStationTypes() const;
 
   MetaData metaData(const std::string &producer) const;
+
+  // Translates WMO,RWID,LPNN,GEOID,Bounding box to FMISID
+  Spine::TaggedFMISIDList translateToFMISID(const boost::posix_time::ptime &starttime,
+                                            const boost::posix_time::ptime &endtime,
+                                            const std::string &stationtype,
+                                            const StationSettings &stationSettings) const;
 
  protected:
   void init();

--- a/observation/EngineParameters.h
+++ b/observation/EngineParameters.h
@@ -19,6 +19,7 @@ struct EngineParameters
 {
   EngineParameters(Spine::ConfigBase &cfg);
 
+  void readDataQualityConfig(Spine::ConfigBase &cfg);
   void readStationTypeConfig(Spine::ConfigBase &cfg);
   bool isParameter(const std::string &alias, const std::string &stationType) const;
   bool isParameterVariant(const std::string &name) const;
@@ -27,9 +28,7 @@ struct EngineParameters
   uint64_t getParameterId(const std::string &alias, const std::string &stationType) const;
 
   // Cache size settings
-  int locationCacheSize;
 
-  std::size_t stationIdCacheSize = 10000;
   std::size_t queryResultBaseCacheSize = 100;
   std::size_t spatiaLitePoolSize;
 
@@ -37,6 +36,7 @@ struct EngineParameters
   std::string dbRegistryFolderPath;
   std::string spatiaLiteFile;
 
+  std::map<std::string, std::string> dataQualityFilters;  // stationtype
   std::map<std::string, std::string> stationTypeMap;
   StationtypeConfig stationtypeConfig;
   ExternalAndMobileProducerConfig externalAndMobileProducerConfig;
@@ -47,7 +47,6 @@ struct EngineParameters
   std::string dbDriverFile;
 
   boost::shared_ptr<StationInfo> stationInfo;
-  Fmi::Cache::Cache<std::string, std::vector<Spine::Station>> locationCache;
   Fmi::Cache::Cache<std::string, std::shared_ptr<QueryResultBase>> queryResultBaseCache;
 
   bool quiet;

--- a/observation/ExternalAndMobileDBInfo.h
+++ b/observation/ExternalAndMobileDBInfo.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "ExternalAndMobileProducerConfig.h"
+#include "SQLDataFilter.h"
 
 namespace SmartMet
 {
@@ -23,7 +24,7 @@ class ExternalAndMobileDBInfo
                         const boost::posix_time::ptime &starttime,
                         const boost::posix_time::ptime &endtime,
                         const std::string &wktAreaFilter,
-                        const std::map<std::string, std::vector<std::string>> &data_filter) const;
+                        const SQLDataFilter &sqlDataFilter) const;
   std::string sqlSelectForCache(const std::string &producer,
                                 const boost::posix_time::ptime &from_data_time,
                                 const boost::posix_time::ptime &from_created_time) const;
@@ -31,7 +32,7 @@ class ExternalAndMobileDBInfo
                                  const boost::posix_time::ptime &starttime,
                                  const boost::posix_time::ptime &endtime,
                                  const std::string &wktAreaFilter,
-                                 const std::map<std::string, std::vector<std::string>> &data_filter,
+                                 const SQLDataFilter &sqlDataFilter,
                                  bool spatialite = false) const;
 
   std::string measurandFieldname(int measurandId) const;

--- a/observation/LocationDataItem.h
+++ b/observation/LocationDataItem.h
@@ -18,7 +18,12 @@ class LocationDataItem
   double elevation;
 };
 
-using LocationDataItems = std::vector<LocationDataItem>;
+struct LocationDataItems : public std::vector<LocationDataItem>
+{
+  std::map<int, std::map<int, int>> default_sensors;  // fmisid -> measurand_id -> sensor_number
+};
+
+// using LocationDataItems = std::vector<LocationDataItem>;
 
 }  // namespace Observation
 }  // namespace Engine

--- a/observation/ObservationCache.h
+++ b/observation/ObservationCache.h
@@ -5,7 +5,7 @@
 #include "LocationItem.h"
 #include "MobileExternalDataItem.h"
 #include "Settings.h"
-#include "StationInfo.h"
+//#include "StationInfo.h"
 #include "Utils.h"
 #include "WeatherDataQCItem.h"
 
@@ -41,40 +41,10 @@ class ObservationCache
   virtual Spine::TimeSeries::TimeSeriesVectorPtr valuesFromCache(
       Settings &settings, const Spine::TimeSeriesGeneratorOptions &timeSeriesOptions) = 0;
 
-  virtual Spine::Stations getStationsByTaggedLocations(
-      const Spine::TaggedLocationList &taggedLocations,
-      const int numberofstations,
-      const std::string &stationtype,
-      const int maxdistance,
-      const std::set<std::string> &stationgroup_codes,
-      const boost::posix_time::ptime &starttime,
-      const boost::posix_time::ptime &endtime) = 0;
-
   virtual bool dataAvailableInCache(const Settings &settings) const = 0;
 
   virtual bool flashIntervalIsCached(const boost::posix_time::ptime &starttime,
                                      const boost::posix_time::ptime &endtime) const = 0;
-
-  virtual void getStationsByBoundingBox(Spine::Stations &stations,
-                                        const Settings &settings) const = 0;
-
-  virtual void updateStationsAndGroups(const StationInfo &info) const = 0;
-
-  virtual Spine::Stations findAllStationsFromGroups(
-      const std::set<std::string> stationgroup_codes,
-      const StationInfo &info,
-      const boost::posix_time::ptime &starttime,
-      const boost::posix_time::ptime &endtime) const = 0;
-
-  virtual bool getStationById(Spine::Station &station,
-                              int station_id,
-                              const std::set<std::string> &stationgroup_codes,
-                              const boost::posix_time::ptime &starttime,
-                              const boost::posix_time::ptime &endtime) const = 0;
-
-  virtual Spine::Stations findStationsInsideArea(const Settings &settings,
-                                                 const std::string &areaWkt,
-                                                 const StationInfo &info) const = 0;
 
   virtual FlashCounts getFlashCount(const boost::posix_time::ptime &starttime,
                                     const boost::posix_time::ptime &endtime,
@@ -113,11 +83,8 @@ class ObservationCache
       const MobileExternalDataItems &mobileExternalCacheData) const = 0;
   virtual void cleanNetAtmoCache(const boost::posix_time::time_duration &timetokeep) const = 0;
 
-  virtual void fillLocationCache(const LocationItems &locations) const = 0;
-
   virtual boost::shared_ptr<std::vector<ObservableProperty> > observablePropertyQuery(
       std::vector<std::string> &parameters, const std::string language) const = 0;
-  virtual bool cacheHasStations() const = 0;
   virtual void shutdown() = 0;
 
  protected:

--- a/observation/ObservationMemoryCache.cpp
+++ b/observation/ObservationMemoryCache.cpp
@@ -243,10 +243,12 @@ void ObservationMemoryCache::clean(const boost::posix_time::ptime& newstarttime)
 // Read observations from the cache. Each shared part must be loaded atomically
 // to be safe in case write/clean is in progress.
 
-LocationDataItems ObservationMemoryCache::read_observations(const Spine::Stations& stations,
-                                                            const Settings& settings,
-                                                            const StationInfo& stationInfo,
-                                                            const QueryMapping& qmap) const
+LocationDataItems ObservationMemoryCache::read_observations(
+    const Spine::Stations& stations,
+    const Settings& settings,
+    const StationInfo& stationInfo,
+    const std::set<std::string>& stationgroup_codes,
+    const QueryMapping& qmap) const
 {
   LocationDataItems ret;
 
@@ -263,7 +265,7 @@ LocationDataItems ObservationMemoryCache::read_observations(const Spine::Station
   for (const auto& station : stations)
   {
     // Accept station only if group condition is satisfied
-    if (!stationInfo.belongsToGroup(station.fmisid, settings.stationgroup_codes))
+    if (!stationInfo.belongsToGroup(station.fmisid, stationgroup_codes))
       continue;
 
     // Find station specific data

--- a/observation/ObservationMemoryCache.h
+++ b/observation/ObservationMemoryCache.h
@@ -57,6 +57,7 @@ class ObservationMemoryCache
   LocationDataItems read_observations(const Spine::Stations &stations,
                                       const Settings &settings,
                                       const StationInfo &stationInfo,
+                                      const std::set<std::string> &stationgroup_codes,
                                       const QueryMapping &qmap) const;
 
  private:

--- a/observation/ParameterMap.cpp
+++ b/observation/ParameterMap.cpp
@@ -1,0 +1,60 @@
+#include "ParameterMap.h"
+
+namespace SmartMet
+{
+namespace Engine
+{
+namespace Observation
+{
+std::string ParameterMap::getParameter(const std::string& name,
+                                       const std::string& stationtype) const
+{
+  if (params.find(name) != params.end())
+  {
+    const StationParameters& stationparams = params.at(name);
+    if (stationparams.find(stationtype) != stationparams.end())
+      return stationparams.at(stationtype);
+  }
+  return std::string();
+}
+// params_id_map
+std::string ParameterMap::getParameterName(const std::string& id,
+                                           const std::string& stationtype) const
+{
+  if (params_id_map.find(stationtype) != params_id_map.end())
+  {
+    const StationParameters& stationparams = params_id_map.at(stationtype);
+    if (stationparams.find(id) != stationparams.end())
+      return stationparams.at(id);
+  }
+  return std::string();
+}
+
+// stationtype -> id -> name
+void ParameterMap::addStationParameterMap(const std::string& name,
+                                          std::map<std::string, std::string> stationparams)
+{
+  params.insert(make_pair(name, stationparams));
+
+  // Add item to params_id_map
+  for (const auto& item : stationparams)
+    params_id_map[item.first][item.second] = name;
+}
+
+const ParameterMap::StationParameters& ParameterMap::at(const std::string& name) const
+{
+  if (params.find(name) != params.end())
+    return params.at(name);
+
+  return emptymap;
+}
+
+ParameterMap::NameToStationParameterMap::const_iterator ParameterMap::find(
+    const std::string& name) const
+{
+  return params.find(name);
+}
+
+}  // namespace Observation
+}  // namespace Engine
+}  // namespace SmartMet

--- a/observation/ParameterMap.h
+++ b/observation/ParameterMap.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <boost/shared_ptr.hpp>
 #include <map>
 #include <string>
 #include <vector>
@@ -19,37 +20,20 @@ class ParameterMap
   using StationParameters = std::map<std::string, std::string>;
   using NameToStationParameterMap = std::map<std::string, StationParameters>;
 
-  std::string getParameter(const std::string& name, const std::string& stationtype) const
-  {
-    if (params.find(name) != params.end())
-    {
-      const StationParameters& stationparams = params.at(name);
-      if (stationparams.find(stationtype) != stationparams.end())
-        return stationparams.at(stationtype);
-    }
-    return std::string();
-  }
-  void addStationParameterMap(const std::string& name,
-                              std::map<std::string, std::string> stationparams)
-  {
-    params.insert(make_pair(name, stationparams));
-  }
-  const StationParameters& at(const std::string& name) const
-  {
-    if (params.find(name) != params.end())
-      return params.at(name);
+  std::string getParameter(const std::string& name, const std::string& stationtype) const;
+  std::string getParameterName(const std::string& id, const std::string& stationtype) const;
 
-    return emptymap;
-  }
-  NameToStationParameterMap::const_iterator find(const std::string& name) const
-  {
-    return params.find(name);
-  }
+  void addStationParameterMap(const std::string& name,
+                              std::map<std::string, std::string> stationparams);
+  const StationParameters& at(const std::string& name) const;
+  NameToStationParameterMap::const_iterator find(const std::string& name) const;
+
   NameToStationParameterMap::const_iterator begin() const { return params.begin(); }
   NameToStationParameterMap::const_iterator end() const { return params.end(); }
 
  private:
   NameToStationParameterMap params;
+  NameToStationParameterMap params_id_map;
   StationParameters emptymap;
 };
 

--- a/observation/PostgreSQLCache.h
+++ b/observation/PostgreSQLCache.h
@@ -35,33 +35,10 @@ class PostgreSQLCache : public ObservationCache
   Spine::TimeSeries::TimeSeriesVectorPtr valuesFromCache(Settings &settings);
   Spine::TimeSeries::TimeSeriesVectorPtr valuesFromCache(
       Settings &settings, const Spine::TimeSeriesGeneratorOptions &timeSeriesOptions);
-  Spine::Stations getStationsByTaggedLocations(const Spine::TaggedLocationList &taggedLocations,
-                                               const int numberofstations,
-                                               const std::string &stationtype,
-                                               const int maxdistance,
-                                               const std::set<std::string> &stationgroup_codes,
-                                               const boost::posix_time::ptime &starttime,
-                                               const boost::posix_time::ptime &endtime);
 
   bool dataAvailableInCache(const Settings &settings) const;
   bool flashIntervalIsCached(const boost::posix_time::ptime &starttime,
                              const boost::posix_time::ptime &endtime) const;
-  void getStationsByBoundingBox(Spine::Stations &stations, const Settings &settings) const;
-  void updateStationsAndGroups(const StationInfo &info) const;
-
-  Spine::Stations findAllStationsFromGroups(const std::set<std::string> stationgroup_codes,
-                                            const StationInfo &info,
-                                            const boost::posix_time::ptime &starttime,
-                                            const boost::posix_time::ptime &endtime) const;
-  bool getStationById(Spine::Station &station,
-                      int station_id,
-                      const std::set<std::string> &stationgroup_codes,
-                      const boost::posix_time::ptime &starttime,
-                      const boost::posix_time::ptime &endtime) const;
-
-  Spine::Stations findStationsInsideArea(const Settings &settings,
-                                         const std::string &areaWkt,
-                                         const StationInfo &info) const;
   FlashCounts getFlashCount(const boost::posix_time::ptime &starttime,
                             const boost::posix_time::ptime &endtime,
                             const Spine::TaggedLocationList &locations) const;
@@ -78,7 +55,6 @@ class PostgreSQLCache : public ObservationCache
   boost::posix_time::ptime getLatestWeatherDataQCTime() const;
   std::size_t fillWeatherDataQCCache(const WeatherDataQCItems &cacheData) const;
   void cleanWeatherDataQCCache(const boost::posix_time::time_duration &timetokeep) const;
-  void fillLocationCache(const LocationItems &locations) const;
 
   // RoadCloud
   bool roadCloudIntervalIsCached(const boost::posix_time::ptime &starttime,
@@ -98,17 +74,11 @@ class PostgreSQLCache : public ObservationCache
 
   boost::shared_ptr<std::vector<ObservableProperty> > observablePropertyQuery(
       std::vector<std::string> &parameters, const std::string language) const;
-  bool cacheHasStations() const;
-
   void shutdown();
 
  private:
   PostgreSQLConnectionPool *itsConnectionPool = nullptr;
-  Spine::Stations getStationsFromPostgreSQL(Settings &settings, boost::shared_ptr<PostgreSQL> db);
-  /*
 
-  Fmi::Cache::Cache<std::string, std::vector<Spine::Station> > itsLocationCache;
-  */
   Fmi::TimeZones itsTimeZones;
 
   void readConfig(Spine::ConfigBase &cfg);
@@ -119,8 +89,6 @@ class PostgreSQLCache : public ObservationCache
   Spine::TimeSeries::TimeSeriesVectorPtr flashValuesFromPostgreSQL(Settings &settings) const;
   Spine::TimeSeries::TimeSeriesVectorPtr roadCloudValuesFromPostgreSQL(Settings &settings) const;
   Spine::TimeSeries::TimeSeriesVectorPtr netAtmoValuesFromPostgreSQL(Settings &settings) const;
-
-  Fmi::Cache::Cache<std::string, std::vector<Spine::Station> > itsLocationCache;
 
   PostgreSQLCacheParameters itsParameters;
 };

--- a/observation/PostgreSQLCacheParameters.h
+++ b/observation/PostgreSQLCacheParameters.h
@@ -47,9 +47,8 @@ struct PostgreSQLCacheParameters
   std::size_t netAtmoInsertCacheSize = 0;
 
   bool quiet = true;
-  bool cacheHasStations;
   boost::shared_ptr<boost::posix_time::time_period> flashCachePeriod;
-  boost::shared_ptr<StationInfo> stationInfo;
+  const boost::shared_ptr<StationInfo>& stationInfo;
   const ParameterMapPtr& parameterMap;
   StationtypeConfig& stationtypeConfig;
   const ExternalAndMobileProducerConfig& externalAndMobileProducerConfig;

--- a/observation/QueryMapping.h
+++ b/observation/QueryMapping.h
@@ -12,12 +12,12 @@ namespace Observation
 {
 struct QueryMapping
 {
-  std::map<int, int> timeseriesPositions;
   std::map<std::string, int> timeseriesPositionsString;
   std::map<std::string, std::string> parameterNameMap;
   std::vector<int> paramVector;
   std::map<std::string, int> specialPositions;
-  std::vector<int> measurandIds;  // all needed measurand ids
+  std::vector<int> measurandIds;                            // all needed measurand ids
+  std::map<int, std::set<int>> sensorNumberToMeasurandIds;  // sensor number -> measurand ids
 };
 
 }  // namespace Observation

--- a/observation/SQLDataFilter.cpp
+++ b/observation/SQLDataFilter.cpp
@@ -1,0 +1,83 @@
+#include "SQLDataFilter.h"
+#include <boost/algorithm/string.hpp>
+#include <spine/Exception.h>
+
+namespace SmartMet
+{
+namespace Engine
+{
+namespace Observation
+{
+void SQLDataFilter::setDataFilter(const std::string& name, const std::string& value)
+{
+  std::vector<std::string> parts;
+  boost::algorithm::split(parts, value, boost::algorithm::is_any_of(","));
+  itsDataFilter.insert(std::make_pair(name, parts));
+}
+
+std::string SQLDataFilter::getSqlClause(const std::string& name, const std::string& dbfield) const
+{
+  try
+  {
+    std::string ret;
+
+    if (itsDataFilter.find(name) == itsDataFilter.end())
+      return ret;
+
+    const auto& conditions = itsDataFilter.at(name);  // OR conditions
+    ret += "(";
+    for (const auto& condition : conditions)
+    {
+      if (ret != "(")
+        ret += " OR ";
+
+      std::string cond = condition;
+      if (cond.find_first_not_of("0123456789") == std::string::npos)
+      {
+        cond.insert(0, dbfield + " = ");
+      }
+      else
+      {
+        boost::replace_all(cond, "lt", dbfield + " <");
+        boost::replace_all(cond, "gt", dbfield + " >");
+        boost::replace_all(cond, "le", dbfield + " <=");
+        boost::replace_all(cond, "ge", dbfield + " >=");
+      }
+
+      ret += cond;
+    }
+    ret += ")";
+    boost::replace_all(ret, "()", "");
+
+    return ret;
+  }
+  catch (...)
+  {
+    throw Spine::Exception::Trace(BCP, "Operation failed!");
+  }
+}
+
+void SQLDataFilter::format(std::ostream& out) const
+{
+  for (const auto& item : itsDataFilter)
+  {
+    out << item.first << " -> ";
+    for (const auto& vector_item : item.second)
+      out << vector_item;
+    out << " " << std::endl;
+  }
+}
+
+bool SQLDataFilter::exist(const std::string& name) const
+{
+  return (itsDataFilter.find(name) != itsDataFilter.end());
+}
+
+bool SQLDataFilter::empty() const
+{
+  return itsDataFilter.empty();
+}
+
+}  // namespace Observation
+}  // namespace Engine
+}  // namespace SmartMet

--- a/observation/SQLDataFilter.h
+++ b/observation/SQLDataFilter.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace SmartMet
+{
+namespace Engine
+{
+namespace Observation
+{
+class SQLDataFilter
+{
+ public:
+  using DataFilterType = std::map<std::string, std::vector<std::string>>;
+  // For example name = "data_quality", value = "le 5"
+  void setDataFilter(const std::string& name, const std::string& value);
+  // Returns SQL clause for dbfield -> name is filter name, dbfield is table field name in database
+  // For example: name = "data_quality", dbfield = "data.flag"
+  std::string getSqlClause(const std::string& name, const std::string& dbfield) const;
+  bool exist(const std::string& name) const;
+  bool empty() const;
+  void format(std::ostream& out) const;
+
+ private:
+  DataFilterType itsDataFilter;
+};
+
+}  // namespace Observation
+}  // namespace Engine
+}  // namespace SmartMet

--- a/observation/Settings.cpp
+++ b/observation/Settings.cpp
@@ -1,0 +1,85 @@
+#include "Settings.h"
+
+namespace SmartMet
+{
+void print_vector(const std::vector<int>& data, const std::string& header, std::ostream& out)
+{
+  if (data.size() == 0)
+    return;
+
+  out << header << std::endl;
+  for (auto i : data)
+    out << i << std::endl;
+}
+
+std::ostream& operator<<(std::ostream& out, const Engine::Observation::Settings& settings)
+{
+  if (settings.taggedLocations.size() > 0)
+  {
+    out << "taggedLocations:" << std::endl;
+    unsigned int i = 0;
+    for (auto l : settings.taggedLocations)
+    {
+      out << "taggedLocation #" << i++ << std::endl;
+      out << "tag: " << l.tag << std::endl;
+      out << SmartMet::Spine::formatLocation(*(l.loc));
+    }
+  }
+
+  print_vector(settings.hours, "hours", out);
+  print_vector(settings.weekdays, "weekdays", out);
+  if (settings.taggedFMISIDs.size() > 0)
+  {
+    out << "fmisids" << std::endl;
+    for (const auto& item : settings.taggedFMISIDs)
+    {
+      out << item.fmisid << std::endl;
+    }
+  }
+
+  out << "locale: " << settings.locale.name() << std::endl;
+
+  if (settings.boundingBox.size() > 0)
+  {
+    out << "boundingBox:" << std::endl;
+    for (auto item : settings.boundingBox)
+      out << item.first << " -> " << item.second << std::endl;
+  }
+
+  if (!settings.sqlDataFilter.empty())
+  {
+    out << "sqlDataFilter:" << std::endl;
+    settings.sqlDataFilter.format(out);  // out << settings.sqlDataFilter;
+  }
+
+  if (settings.producer_ids.size() > 0)
+  {
+    out << "producer_ids:" << std::endl;
+    for (auto item : settings.producer_ids)
+      out << item << std::endl;
+  }
+
+  out << "cacheKey: " << settings.cacheKey << std::endl;
+  out << "format: " << settings.format << std::endl;
+  out << "language: " << settings.language << std::endl;
+  out << "localename: " << settings.localename << std::endl;
+  out << "missingtext: " << settings.missingtext << std::endl;
+  out << "stationtype: " << settings.stationtype << std::endl;
+  out << "timeformat: " << settings.timeformat << std::endl;
+  out << "timestring: " << settings.timestring << std::endl;
+  out << "timezone: " << settings.timezone << std::endl;
+  out << "wktArea: " << settings.wktArea << std::endl;
+  out << "starttime: " << settings.starttime << std::endl;
+  out << "endtime: " << settings.endtime << std::endl;
+  out << "maxdistance: " << settings.maxdistance << std::endl;
+  out << "numberofstations: " << settings.numberofstations << std::endl;
+  out << "timestep: " << settings.timestep << std::endl;
+  out << "allplaces: " << settings.allplaces << std::endl;
+  out << "latest: " << settings.latest << std::endl;
+  out << "starttimeGiven: " << settings.starttimeGiven << std::endl;
+  out << "useCommonQueryMethod: " << settings.useCommonQueryMethod << std::endl;
+  out << "useDataCache: " << settings.useDataCache << std::endl;
+
+  return out;
+}
+}  // namespace SmartMet

--- a/observation/Settings.h
+++ b/observation/Settings.h
@@ -1,13 +1,14 @@
 #pragma once
 
-#include <spine/Location.h>
-#include <spine/Parameter.h>
-#include <spine/ValueFormatter.h>
-
+#include "SQLDataFilter.h"
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/date_time/local_time/local_time.hpp>
 #include <boost/date_time/local_time_adjustor.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
+#include <spine/Location.h>
+#include <spine/Parameter.h>
+#include <spine/Station.h>
+#include <spine/ValueFormatter.h>
 #include <locale>
 #include <set>
 
@@ -17,24 +18,38 @@ namespace Engine
 {
 namespace Observation
 {
+/*
+struct FlashArea
+{
+double longitude;  // for flash queries
+double latitude;
+double radius;
+};
+
+
+struct FlashOptions
+{
+std::vector<FlashArea> flash_areas;
+std::map<std::string, double> bbox;
+};
+*/
 class Settings
 {
  public:
-  SmartMet::Spine::LocationList locations;
   SmartMet::Spine::TaggedLocationList taggedLocations;
+  SmartMet::Spine::TaggedFMISIDList taggedFMISIDs;
   std::vector<SmartMet::Spine::Parameter> parameters;
-  std::vector<int> area_geoids;
-  std::vector<int> fmisids;
-  std::vector<int> geoids;
   std::vector<int> hours;
-  std::vector<int> lpnns;
   std::vector<int> weekdays;
-  std::vector<int> wmos;
-  std::vector<std::map<std::string, double>> coordinates;
   std::locale locale{"fi_FI"};
   std::map<std::string, double> boundingBox;  // no default value
-  std::map<std::string, std::vector<std::string>> dataFilter;
-  std::set<std::string> stationgroup_codes;
+
+  // Filters mobile and external data and sounding data. Filtering is
+  // based on given parameters, for example "stations_no" -> "1020,1046"
+  // returns data rows only where station_no == 1020 or 1046
+  //  std::map<std::string, std::vector<std::string>> dataFilter;
+  SQLDataFilter sqlDataFilter;
+
   std::set<uint> producer_ids;
   std::string cacheKey;
   std::string format = "ascii";
@@ -46,24 +61,18 @@ class Settings
   std::string timestring = "";
   std::string timezone = "localtime";
   std::string wktArea;
-  boost::posix_time::ptime endtime = boost::posix_time::second_clock::universal_time(); // jow
-  boost::posix_time::ptime starttime = boost::posix_time::second_clock::universal_time() - boost::posix_time::hours(24);
+  boost::posix_time::ptime endtime = boost::posix_time::second_clock::universal_time();  // now
+  boost::posix_time::ptime starttime =
+      boost::posix_time::second_clock::universal_time() - boost::posix_time::hours(24);
   double maxdistance = 50000;
   int numberofstations = 1;
   int timestep = 1;
   bool allplaces = false;
-  bool boundingBoxIsGiven = false;
   bool latest = false;
   bool starttimeGiven = false;
   bool useCommonQueryMethod = false;  // default is false
-  bool useDataCache = true;          // default is true
-
-  // Filters mobile and external data and sounding data. Filtering is
-  // based on given parameters, for example "stations_no" -> "1020,1046"
-  // returns data rows only where station_no == 1020 or 1046
-  
+  bool useDataCache = true;           // default is true
 };
-
 }  // namespace Observation
 }  // namespace Engine
 }  // namespace SmartMet

--- a/observation/SpatiaLiteCache.h
+++ b/observation/SpatiaLiteCache.h
@@ -37,33 +37,10 @@ class SpatiaLiteCache : public ObservationCache
   Spine::TimeSeries::TimeSeriesVectorPtr valuesFromCache(Settings &settings);
   Spine::TimeSeries::TimeSeriesVectorPtr valuesFromCache(
       Settings &settings, const Spine::TimeSeriesGeneratorOptions &timeSeriesOptions);
-  Spine::Stations getStationsByTaggedLocations(const Spine::TaggedLocationList &taggedLocations,
-                                               const int numberofstations,
-                                               const std::string &stationtype,
-                                               const int maxdistance,
-                                               const std::set<std::string> &stationgroup_codes,
-                                               const boost::posix_time::ptime &starttime,
-                                               const boost::posix_time::ptime &endtime);
 
   bool dataAvailableInCache(const Settings &settings) const;
   bool flashIntervalIsCached(const boost::posix_time::ptime &starttime,
                              const boost::posix_time::ptime &endtime) const;
-  void getStationsByBoundingBox(Spine::Stations &stations, const Settings &settings) const;
-  void updateStationsAndGroups(const StationInfo &info) const;
-
-  Spine::Stations findAllStationsFromGroups(const std::set<std::string> stationgroup_codes,
-                                            const StationInfo &info,
-                                            const boost::posix_time::ptime &starttime,
-                                            const boost::posix_time::ptime &endtime) const;
-  bool getStationById(Spine::Station &station,
-                      int station_id,
-                      const std::set<std::string> &stationgroup_codes,
-                      const boost::posix_time::ptime &starttime,
-                      const boost::posix_time::ptime &endtime) const;
-
-  Spine::Stations findStationsInsideArea(const Settings &settings,
-                                         const std::string &areaWkt,
-                                         const StationInfo &info) const;
   FlashCounts getFlashCount(const boost::posix_time::ptime &starttime,
                             const boost::posix_time::ptime &endtime,
                             const Spine::TaggedLocationList &locations) const;
@@ -79,7 +56,6 @@ class SpatiaLiteCache : public ObservationCache
   boost::posix_time::ptime getLatestWeatherDataQCTime() const;
   std::size_t fillWeatherDataQCCache(const WeatherDataQCItems &cacheData) const;
   void cleanWeatherDataQCCache(const boost::posix_time::time_duration &timetokeep) const;
-  void fillLocationCache(const LocationItems &locations) const;
 
   // RoadCloud
   bool roadCloudIntervalIsCached(const boost::posix_time::ptime &starttime,
@@ -101,7 +77,6 @@ class SpatiaLiteCache : public ObservationCache
 
   boost::shared_ptr<std::vector<ObservableProperty> > observablePropertyQuery(
       std::vector<std::string> &parameters, const std::string language) const;
-  bool cacheHasStations() const;
 
   void shutdown();
 
@@ -116,7 +91,6 @@ class SpatiaLiteCache : public ObservationCache
   void readConfig(Spine::ConfigBase &cfg);
 
   SpatiaLiteConnectionPool *itsConnectionPool = nullptr;
-  Fmi::Cache::Cache<std::string, std::vector<Spine::Station> > itsLocationCache;
   Fmi::TimeZones itsTimeZones;
 
   SpatiaLiteCacheParameters itsParameters;
@@ -143,10 +117,6 @@ class SpatiaLiteCache : public ObservationCache
   mutable boost::posix_time::ptime itsNetAtmoTimeIntervalStart;
   mutable boost::posix_time::ptime itsNetAtmoTimeIntervalEnd;
 
-  // Cache for station id searches
-  using StationIdCache = Fmi::Cache::Cache<std::size_t, Spine::Station>;
-  mutable StationIdCache itsStationIdCache;
-
   // Caches for last inserted rows to avoid duplicate inserts
   mutable InsertStatus itsDataInsertCache;
   mutable InsertStatus itsWeatherQCInsertCache;
@@ -156,8 +126,6 @@ class SpatiaLiteCache : public ObservationCache
 
   // Memory caches smaller than the spatialite cache itself
   std::unique_ptr<FlashMemoryCache> itsFlashMemoryCache;
-  // ObservationDataMemoryCache itsObservationDataMemoryCache; // UNIMPLEMENTED
-  // WeatherDataQCMemoryCache itsWeatherDataQCMemoryCache; // UNIMPLEMENTED
 };
 
 }  // namespace Observation

--- a/observation/SpatiaLiteCacheParameters.h
+++ b/observation/SpatiaLiteCacheParameters.h
@@ -28,24 +28,23 @@ class StationtypeConfig;
 struct SpatiaLiteCacheParameters
 {
   SpatiaLiteCacheParameters(const EngineParametersPtr& p)
-    : stationInfo(p->stationInfo),
-      quiet(p->quiet),
-      stationtypeConfig(p->stationtypeConfig),
-      externalAndMobileProducerConfig(p->externalAndMobileProducerConfig),
-      parameterMap(p->parameterMap)
+      : stationInfo(p->stationInfo),
+        quiet(p->quiet),
+        stationtypeConfig(p->stationtypeConfig),
+        externalAndMobileProducerConfig(p->externalAndMobileProducerConfig),
+        parameterMap(p->parameterMap)
   {
   }
 
   SpatiaLiteOptions sqlite;
-  boost::shared_ptr<StationInfo> stationInfo;
+  const boost::shared_ptr<StationInfo>& stationInfo;
   boost::shared_ptr<boost::posix_time::time_period> flashCachePeriod;
   std::string cacheFile;
   std::size_t maxInsertSize = 5000;
   int connectionPoolSize = 0;
-  bool cacheHasStations = false;
   bool quiet = true;
 
-  StationtypeConfig& stationtypeConfig;
+  const StationtypeConfig& stationtypeConfig;
   const ExternalAndMobileProducerConfig& externalAndMobileProducerConfig;
   const ParameterMapPtr& parameterMap;
 };

--- a/observation/SpatiaLiteDriverParameters.h
+++ b/observation/SpatiaLiteDriverParameters.h
@@ -24,7 +24,6 @@ struct SpatiaLiteDriverParameters
   SpatiaLiteDriverParameters(const EngineParametersPtr& p)
       : parameterMap(p->parameterMap),
         stationInfo(p->stationInfo),
-        locationCache(p->locationCache),
         queryResultBaseCache(p->queryResultBaseCache),
         observationCache(p->observationCache),
         stationtypeConfig(p->stationtypeConfig)
@@ -34,7 +33,6 @@ struct SpatiaLiteDriverParameters
   // Geonames::Engine* geonames;
   const ParameterMapPtr& parameterMap;
   boost::shared_ptr<StationInfo> stationInfo;
-  Fmi::Cache::Cache<std::string, std::vector<Spine::Station> >& locationCache;
   Fmi::Cache::Cache<std::string, std::shared_ptr<QueryResultBase> >& queryResultBaseCache;
   boost::shared_ptr<ObservationCache> observationCache;
   StationtypeConfig& stationtypeConfig;

--- a/observation/StationInfo.h
+++ b/observation/StationInfo.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "StationLocation.h"
 #include <macgyver/NearTree.h>
 #include <macgyver/NearTreeLatLon.h>
 #include <spine/Station.h>
@@ -34,6 +35,7 @@ class StationInfo
 {
  public:
   SmartMet::Spine::Stations stations;  // all known stations
+  StationLocations stationLocations;   // all station locations
 
   void serialize(const std::string& filename) const;
   void unserialize(const std::string& filename);
@@ -54,6 +56,8 @@ class StationInfo
   SmartMet::Spine::Stations findFmisidStations(const std::vector<int>& fmisids,
                                                const boost::posix_time::ptime& starttime,
                                                const boost::posix_time::ptime& endtime) const;
+  SmartMet::Spine::Stations findFmisidStations(
+      const SmartMet::Spine::TaggedFMISIDList& taggedFMISIDs) const;
 
   SmartMet::Spine::Stations findWmoStations(const std::vector<int>& wmos,
                                             const boost::posix_time::ptime& starttime,
@@ -71,6 +75,11 @@ class StationInfo
                                                 const boost::posix_time::ptime& starttime,
                                                 const boost::posix_time::ptime& endtime) const;
 
+  Spine::Stations findStationsInsideArea(const std::set<std::string>& groups,
+                                         const boost::posix_time::ptime& starttime,
+                                         const boost::posix_time::ptime& endtime,
+                                         const std::string& wkt) const;
+
   SmartMet::Spine::Stations findStationsInsideBox(double minx,
                                                   double miny,
                                                   double maxx,
@@ -85,9 +94,7 @@ class StationInfo
 
  private:
   void update() const;
-
   // Mapping from coordinates to stations
-
   using StationTree =
       Fmi::NearTree<StationNearTreeLatLon, Fmi::NearTreeLatLonDistance<StationNearTreeLatLon>>;
 

--- a/observation/StationLocation.cpp
+++ b/observation/StationLocation.cpp
@@ -1,0 +1,77 @@
+#include "StationLocation.h"
+
+namespace SmartMet
+{
+namespace Engine
+{
+namespace Observation
+{
+static StationLocation emptyLocation = StationLocation();
+static StationLocationVector emptyLocationVector = StationLocationVector();
+
+const StationLocation& StationLocations::getLocation(int fmisid,
+                                                     const boost::posix_time::ptime& t) const
+{
+  const StationLocationVector& allLocations = getAllLocations(fmisid);
+
+  for (const auto& loc : allLocations)
+  {
+    if (t >= loc.location_start && t <= loc.location_end)
+      return loc;
+  }
+
+  return emptyLocation;
+}
+
+const StationLocation& StationLocations::getCurrentLocation(int fmisid) const
+{
+  const StationLocationVector& allLocations = getAllLocations(fmisid);
+  boost::posix_time::ptime now = boost::posix_time::second_clock::universal_time();
+
+  for (const auto& loc : allLocations)
+  {
+    if (now >= loc.location_start && now <= loc.location_end)
+      return loc;
+  }
+
+  return emptyLocation;
+}
+
+const StationLocationVector& StationLocations::getAllLocations(int fmisid) const
+{
+  if (find(fmisid) == end())
+    return emptyLocationVector;
+
+  return at(fmisid);
+}
+
+unsigned int StationLocations::getNumberOfLocations(int fmisid) const
+{
+  if (find(fmisid) == end())
+    return 0;
+
+  return at(fmisid).size();
+}
+
+bool StationLocations::isCurrentlyActive(int fmisid) const
+{
+  return (getCurrentLocation(fmisid).fmisid == -1);
+}
+
+}  // namespace Observation
+}  // namespace Engine
+}  // namespace SmartMet
+
+std::ostream& operator<<(std::ostream& out,
+                         const SmartMet::Engine::Observation::StationLocations& locations)
+{
+  for (const auto& item : locations)
+  {
+    out << item.first << std::endl;
+    for (const auto& loc : item.second)
+      out << "  " << loc.location_start << "..." << loc.location_end << ", " << loc.longitude
+          << ", " << loc.latitude << ", " << loc.elevation << ", " << loc.x << ", " << loc.y << ", "
+          << loc.country_id << ", " << loc.time_zone_name << std::endl;
+  }
+  return out;
+};

--- a/observation/StationLocation.h
+++ b/observation/StationLocation.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <boost/date_time/posix_time/posix_time.hpp>
+
+namespace SmartMet
+{
+namespace Engine
+{
+namespace Observation
+{
+class StationLocation
+{
+ public:
+  int location_id;
+  int fmisid;
+  int country_id;
+  boost::posix_time::ptime location_start;
+  boost::posix_time::ptime location_end;
+  double longitude;
+  double latitude;
+  double x;
+  double y;
+  double elevation;
+  std::string time_zone_name;
+  std::string time_zone_abbrev;
+
+  StationLocation()
+      : location_id(-1),
+        fmisid(-1),
+        location_start(boost::posix_time::not_a_date_time),
+        location_end(boost::posix_time::not_a_date_time),
+        longitude(-1.0),
+        latitude(-1.0),
+        x(-1.0),
+        y(-1.0),
+        elevation(-1.0),
+        time_zone_name(""),
+        time_zone_abbrev("")
+  {
+  }
+};
+
+// Vector of all locations
+using StationLocationVector = std::vector<StationLocation>;
+
+// FMISID -> StationLocations
+using StatationLocationMap = std::map<int, StationLocationVector>;
+
+class StationLocations : public StatationLocationMap
+{
+ public:
+  const StationLocation& getLocation(int fmisid, const boost::posix_time::ptime& t) const;
+  const StationLocation& getCurrentLocation(int fmisid) const;
+  const StationLocationVector& getAllLocations(int fmisid) const;
+  unsigned int getNumberOfLocations(int fmisid) const;
+  bool isCurrentlyActive(int fmisid) const;
+};
+
+}  // namespace Observation
+}  // namespace Engine
+}  // namespace SmartMet
+
+std::ostream& operator<<(std::ostream& out,
+                         const SmartMet::Engine::Observation::StationLocations& locations);

--- a/observation/StationSettings.h
+++ b/observation/StationSettings.h
@@ -1,0 +1,44 @@
+#pragma once
+
+namespace SmartMet
+{
+namespace Engine
+{
+namespace Observation
+{
+struct GeoIdSettings
+{
+  std::vector<int> geoids;
+  double maxdistance;
+  int numberofstations;
+  std::string language;
+};
+
+struct NearestStationSettings
+{
+  double longitude;
+  double latitude;
+  double maxdistance;
+  int numberofstations;
+  std::string tag{""};  // This is put in place parameter (station.tag)
+  NearestStationSettings(double lon, double lat, double maxd, int nos, const std::string& t)
+      : longitude(lon), latitude(lat), maxdistance(maxd), numberofstations(nos), tag(t)
+  {
+  }
+};
+
+using BoundingBoxSettings = std::map<std::string, double>;
+
+struct StationSettings
+{
+  std::vector<int> lpnns;
+  std::vector<int> wmos;
+  std::vector<int> fmisids;
+  GeoIdSettings geoid_settings;
+  std::vector<NearestStationSettings> nearest_station_settings;
+  BoundingBoxSettings bounding_box_settings;
+};
+
+}  // namespace Observation
+}  // namespace Engine
+}  // namespace SmartMet

--- a/observation/Utils.cpp
+++ b/observation/Utils.cpp
@@ -141,16 +141,20 @@ double rad2deg(double rad)
   return (rad * 180 / PI);
 }
 
-std::string windCompass8(double direction)
+std::string windCompass8(double direction, const std::string& missingValue)
 {
+  if (direction < 0)
+    return missingValue;
   static const std::string names[] = {"N", "NE", "E", "SE", "S", "SW", "W", "NW"};
 
   int i = static_cast<int>((direction + 22.5) / 45) % 8;
   return names[i];
 }
 
-std::string windCompass16(double direction)
+std::string windCompass16(double direction, const std::string& missingValue)
 {
+  if (direction < 0)
+    return missingValue;
   static const std::string names[] = {"N",
                                       "NNE",
                                       "NE",
@@ -172,8 +176,10 @@ std::string windCompass16(double direction)
   return names[i];
 }
 
-std::string windCompass32(double direction)
+std::string windCompass32(double direction, const std::string& missingValue)
 {
+  if (direction < 0)
+    return missingValue;
   static const std::string names[] = {"N", "NbE", "NNE", "NEbN", "NE", "NEbE", "ENE", "EbN",
                                       "E", "EbS", "ESE", "SEbE", "SE", "SEbS", "SSE", "SbE",
                                       "S", "SbW", "SSW", "SWbS", "SW", "SWbW", "WSW", "WbS",
@@ -329,36 +335,6 @@ void logMessage(const std::string& message, bool quiet)
   {
     if (!quiet)
       std::cout << Spine::log_time_str() << ' ' << message << std::endl;
-  }
-  catch (...)
-  {
-    throw Spine::Exception::Trace(BCP, "Operation failed!");
-  }
-}
-
-std::string getLocationCacheKey(int geoID,
-                                int numberOfStations,
-                                std::string stationType,
-                                int maxDistance,
-                                const boost::posix_time::ptime& starttime,
-                                const boost::posix_time::ptime& endtime)
-{
-  try
-  {
-    std::string locationCacheKey = "";
-
-    locationCacheKey += Fmi::to_string(geoID);
-    locationCacheKey += "-";
-    locationCacheKey += Fmi::to_string(numberOfStations);
-    locationCacheKey += "-";
-    locationCacheKey += stationType;
-    locationCacheKey += "-";
-    locationCacheKey += Fmi::to_string(maxDistance);
-    locationCacheKey += "-";
-    locationCacheKey += Fmi::to_iso_string(starttime);
-    locationCacheKey += "-";
-    locationCacheKey += Fmi::to_iso_string(endtime);
-    return locationCacheKey;
   }
   catch (...)
   {

--- a/observation/Utils.h
+++ b/observation/Utils.h
@@ -52,9 +52,9 @@ void calculateStationDirection(SmartMet::Spine::Station& station);
 double deg2rad(double deg);
 double rad2deg(double rad);
 
-std::string windCompass8(double direction);
-std::string windCompass16(double direction);
-std::string windCompass32(double direction);
+std::string windCompass8(double direction, const std::string& missingValue);
+std::string windCompass16(double direction, const std::string& missingValue);
+std::string windCompass32(double direction, const std::string& missingValue);
 
 std::string parseParameterName(const std::string& parameter);
 int parseSensorNumber(const std::string& parameter);
@@ -88,19 +88,6 @@ std::string timeToString(const boost::posix_time::ptime& time);
  */
 // ----------------------------------------------------------------------
 void logMessage(const std::string& message, bool quiet);
-
-// ----------------------------------------------------------------------
-/*!
- * \brief Returns location cacahe key
- */
-// ----------------------------------------------------------------------
-
-std::string getLocationCacheKey(int geoID,
-                                int numberOfStations,
-                                std::string stationType,
-                                int maxDistance,
-                                const boost::posix_time::ptime& starttime,
-                                const boost::posix_time::ptime& endtime);
 
 // ----------------------------------------------------------------------
 /*!

--- a/smartmet-engine-observation.spec
+++ b/smartmet-engine-observation.spec
@@ -3,7 +3,7 @@
 %define SPECNAME smartmet-engine-%{DIRNAME}
 Summary: SmartMet Observation Engine
 Name: %{SPECNAME}
-Version: 20.4.18
+Version: 20.5.12
 Release: 1%{?dist}.fmi
 License: FMI
 Group: SmartMet/Engines
@@ -15,7 +15,7 @@ BuildRequires: gcc-c++
 BuildRequires: make
 BuildRequires: libconfig-devel
 BuildRequires: boost169-devel
-BuildRequires: smartmet-library-spine-devel >= 20.4.18
+BuildRequires: smartmet-library-spine-devel >= 20.5.12
 BuildRequires: smartmet-engine-geonames-devel >= 20.4.18
 BuildRequires: libspatialite-devel >= 4.3.0a
 BuildRequires: sqlite-devel >= 3.22.0
@@ -30,7 +30,7 @@ Requires: fmt >= 5.2.0
 Requires: libconfig
 Requires: smartmet-server >= 20.4.18
 Requires: smartmet-engine-geonames >= 20.4.18
-Requires: smartmet-library-spine >= 20.4.18
+Requires: smartmet-library-spine >= 20.5.12
 Requires: smartmet-library-locus >= 20.4.18
 Requires: smartmet-library-macgyver >= 20.4.18
 Requires: libatomic
@@ -92,6 +92,16 @@ rm -rf $RPM_BUILD_ROOT
 %{_includedir}/smartmet/engines/%{DIRNAME}
 
 %changelog
+* Tue May 12 2020  Anssi Reponen <anssi.reponen@fmi.fi> - 20.5.12-1.fmi
+- Major code refactoring. Big changes in Engine-interface (BRAINSTORM-1678)
+- Stations (FMISIDs) are resolved in a seprate function call before actual observation-query
+- All relevant information of stations is kept in memory, as a result the following tables 
+has been removed from cache: STATIONS, STATION_GROUPS, GROUP_MEMBERS, LOCATIONS
+- Support for sensors added, as a result the related tickets has been fixed (BRAINSTORM-1549)
+- Fixed non-active station bug (BRAINSTORM-1718,BRAINSTORM-568,BRAINSTORM-569)
+- Fixed bug in query with numberofstations-option (BRAINSTORM-1609)
+- Added support for data_quality option (BRAINSTORM-1706)
+
 * Sat Apr 18 2020 Mika Heiskanen <mika.heiskanen@fmi.fi> - 20.4.18-1.fmi
 - Upgraded to Boost 1.69
 


### PR DESCRIPTION
…678)

- Stations (FMISIDs) are resolved in a seprate function call before actual observation-query
- All relevant information of stations is kept in memory, as a result the following tables
has been removed from cache: STATIONS, STATION_GROUPS, GROUP_MEMBERS, LOCATIONS
- Support for sensors added, as a result the related tickets has been fixed (BRAINSTORM-1549)
- Fixed non-active station bug (BRAINSTORM-1718,BRAINSTORM-568,BRAINSTORM-569)
- Fixed bug in query with numberofstations-option (BRAINSTORM-1609)
- Added support for data_quality option (BRAINSTORM-1706)