### PR TITLE
Fixed data_quality condition in SQL statements (BRAINSTORM-2063)

### DIFF
--- a/observation/EngineParameters.cpp
+++ b/observation/EngineParameters.cpp
@@ -109,7 +109,7 @@ void EngineParameters::readDataQualityConfig(Spine::ConfigBase &cfg)
   {
     // Default filter
     auto default_filter =
-        cfg.get_optional_config_param<std::string>("data_quality_filter.default", "le 5");
+        cfg.get_optional_config_param<std::string>("data_quality_filter.default_filter", "le 5");
 
     std::vector<std::string> stationtypes =
         cfg.get_mandatory_config_array<std::string>("stationtypes");

--- a/observation/ObservationMemoryCache.cpp
+++ b/observation/ObservationMemoryCache.cpp
@@ -310,7 +310,7 @@ LocationDataItems ObservationMemoryCache::read_observations(
       // Skip unwanted parameters similarly to SpatiaLite.cpp read_observations
       // Check sensor number and data_quality condition
       bool sensorOK = false;
-      if ((obs->measurand_no == 1 && valid_sensors.find(-1) != valid_sensors.end()) ||
+      if ((obs->measurand_no == 1 &&  (valid_sensors.find(-1) != valid_sensors.end() || valid_sensors.empty())) ||
           valid_sensors.find(obs->sensor_no) != valid_sensors.end())
         sensorOK = true;
 

--- a/observation/PostgreSQLCacheDB.cpp
+++ b/observation/PostgreSQLCacheDB.cpp
@@ -2234,8 +2234,8 @@ std::string PostgreSQLCacheDB::sqlSelectFromWeatherDataQCData(const Settings &se
           "AND data.obstime BETWEEN '" +
           Fmi::to_iso_extended_string(settings.starttime) + "' AND '" +
           Fmi::to_iso_extended_string(settings.endtime) + "' AND data.parameter IN (" + params +
-          ") "
-          "GROUP BY data.fmisid, data.parameter, data.value, data.sensor_no, data.flag "
+		  ") AND " + settings.sqlDataFilter.getSqlClause("data_quality", "data.flag") +
+          " GROUP BY data.fmisid, data.parameter, data.value, data.sensor_no, data.flag "
           "ORDER BY fmisid ASC, obstime ASC";
     }
     else
@@ -2250,8 +2250,8 @@ std::string PostgreSQLCacheDB::sqlSelectFromWeatherDataQCData(const Settings &se
           "AND data.obstime BETWEEN '" +
           Fmi::to_iso_extended_string(settings.starttime) + "' AND '" +
           Fmi::to_iso_extended_string(settings.endtime) + "' AND data.parameter IN (" + params +
-          ") "
-          "GROUP BY data.fmisid, data.obstime, data.parameter, data.sensor_no "
+		  ") AND " + settings.sqlDataFilter.getSqlClause("data_quality", "data.flag") +
+          " GROUP BY data.fmisid, data.obstime, data.parameter, data.sensor_no "
           "ORDER BY fmisid ASC, obstime ASC";
     }
 

--- a/observation/PostgreSQLObsDB.cpp
+++ b/observation/PostgreSQLObsDB.cpp
@@ -618,8 +618,8 @@ std::string PostgreSQLObsDB::sqlSelectFromWeatherDataQCData(const Settings &sett
           "AND data.obstime BETWEEN '" +
           Fmi::to_iso_extended_string(settings.starttime) + "' AND '" +
           Fmi::to_iso_extended_string(settings.endtime) + "' AND data.parameter IN (" + params +
-          ") "
-          "GROUP BY data.fmisid, data.obstime, data.parameter, data.value, data.sensor_no, "
+          ") AND " + settings.sqlDataFilter.getSqlClause("data_quality", "data.flag") +
+          " GROUP BY data.fmisid, data.obstime, data.parameter, data.value, data.sensor_no, "
           "data.flag "
           "ORDER BY fmisid ASC, obstime ASC";
     }
@@ -635,8 +635,8 @@ std::string PostgreSQLObsDB::sqlSelectFromWeatherDataQCData(const Settings &sett
           "AND data.obstime BETWEEN '" +
           Fmi::to_iso_extended_string(settings.starttime) + "' AND '" +
           Fmi::to_iso_extended_string(settings.endtime) + "' AND data.parameter IN (" + params +
-          ") "
-          "GROUP BY  data.fmisid, data.obstime, data.parameter, data.value, data.sensor_no, "
+          ") AND " + settings.sqlDataFilter.getSqlClause("data_quality", "data.flag") +
+          " GROUP BY  data.fmisid, data.obstime, data.parameter, data.value, data.sensor_no, "
           "data.flag "
           "ORDER BY fmisid ASC, obstime ASC";
     }

--- a/observation/SQLDataFilter.cpp
+++ b/observation/SQLDataFilter.cpp
@@ -56,6 +56,7 @@ std::string SQLDataFilter::getSqlClause(const std::string& name, const std::stri
         boost::replace_all(cond, "gt", dbfield + " >");
         boost::replace_all(cond, "le", dbfield + " <=");
         boost::replace_all(cond, "ge", dbfield + " >=");
+        boost::replace_all(cond, "eq", dbfield + " =");
       }
 
       ret += cond;
@@ -147,6 +148,10 @@ bool SQLDataFilter::valueOK(const std::string& name, int val) const
           {
             res = (val >= int_value(cnd, cnd.find("ge") + 2));
           }
+          else if (cnd.find("eq") != std::string::npos)
+          {
+            res = (val == int_value(cnd, cnd.find("eq") + 2));
+          }
           cond_set.insert(res);
         }
 
@@ -169,7 +174,7 @@ bool SQLDataFilter::valueOK(const std::string& name, int val) const
       {
         return true;
       }
-
+	
     return false;
   }
   catch (...)

--- a/observation/SpatiaLite.cpp
+++ b/observation/SpatiaLite.cpp
@@ -2713,8 +2713,8 @@ std::string SpatiaLite::sqlSelectFromWeatherDataQCData(const Settings &settings,
           "AND data.obstime BETWEEN " +
           Fmi::to_string(starttime) + " AND " + Fmi::to_string(endtime) +
           " AND data.parameter IN (" + params +
-          ") "
-          "GROUP BY data.fmisid, data.parameter, data.sensor_no "
+          ") AND " + settings.sqlDataFilter.getSqlClause("data_quality", "data.flag") +
+          " GROUP BY data.fmisid, data.parameter, data.sensor_no "
           "ORDER BY fmisid ASC, obstime ASC;";
     }
     else
@@ -2729,8 +2729,8 @@ std::string SpatiaLite::sqlSelectFromWeatherDataQCData(const Settings &settings,
           "AND data.obstime BETWEEN " +
           Fmi::to_string(starttime) + " AND " + Fmi::to_string(endtime) +
           " AND data.parameter IN (" + params +
-          ") "
-          "GROUP BY data.fmisid, data.obstime, data.parameter, "
+          ") AND " + settings.sqlDataFilter.getSqlClause("data_quality", "data.flag") +
+          " GROUP BY data.fmisid, data.obstime, data.parameter, "
           "data.sensor_no "
           "ORDER BY fmisid ASC, obstime ASC;";
     }

--- a/smartmet-engine-observation.spec
+++ b/smartmet-engine-observation.spec
@@ -3,7 +3,7 @@
 %define SPECNAME smartmet-engine-%{DIRNAME}
 Summary: SmartMet Observation Engine
 Name: %{SPECNAME}
-Version: 21.5.17
+Version: 21.5.18
 Release: 1%{?dist}.fmi
 License: FMI
 Group: SmartMet/Engines
@@ -108,6 +108,11 @@ rm -rf $RPM_BUILD_ROOT
 %{_includedir}/smartmet/engines/%{DIRNAME}
 
 %changelog
+* Tue May 18 2021 Anssi Reponen <anssi.reponen@fmi.fi> - 21.5.18-1.fmi
+- Fixed data_quality condition in SQL statements (BRAINSTORM-2063)
+- Fixed reading of default data_quality condition from configuration file
+- Added 'eq' operator in SQLDataFilter
+
 * Mon May 17 2021 Mika Heiskanen <mika.heiskanen@fmi.fi> - 21.5.17-1.fmi
 - Fixed ObservationCacheAdmihnPostgreSQL to return correct last observation times
 - Use only modified_last in PG cache updates, adding an OR for modified_last is very slow


### PR DESCRIPTION
- Fixed reading of default data_quality condition from configuration file
- Added 'eq' operator in SQLDataFilter