### PR TITLE
Return a reference to a static variable instead of temporary

### DIFF
--- a/observation/DisabledEngine.cpp
+++ b/observation/DisabledEngine.cpp
@@ -135,7 +135,8 @@ Spine::TaggedFMISIDList DisabledEngine::translateToFMISID(
 
 const ProducerMeasurandInfo& DisabledEngine::getMeasurandInfo() const
 {
-  return {};
+  static ProducerMeasurandInfo empty{};
+  return empty;
 }
 
 Fmi::DateTime DisabledEngine::getLatestDataUpdateTime(const std::string& /* producer */,


### PR DESCRIPTION
Compiler warned about returning a reference to a temporary, fix that.